### PR TITLE
Allow custom settings on interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ files for further details.
   `network-orchestrator/group_vars/all.yml` to the `other_interfaces` variable.
 
   An example of such a configuration can be found in
-  `network-orchestrator/group_vars/example.all.yml`
+  `network-orchestrator/group_vars/example.all.yml`.
 
 4. If you take a look at the `sim-run.sh` script you can see a reference to a 
 file that is not currently there `network-orchestrator/simulation-run.cfg`. If 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ of the file name. Change the variables for your needs. If you dont need static
 routing dont copy the snippet example. Please see the comments inside the example 
 files for further details.
 
+- if an interface needs custom settings, then set the interfaces as type "Other"
+  in Netbox and add the special settings to
+  `network-orchestrator/group_vars/all.yml` to the `other_interfaces` variable.
+
+  An example of such a configuration can be found in
+  `network-orchestrator/group_vars/example.all.yml`
+
 4. If you take a look at the `sim-run.sh` script you can see a reference to a 
 file that is not currently there `network-orchestrator/simulation-run.cfg`. If 
 you want to push to a simulation environment just `cp production-run.cfg simulation-run.cfg` 

--- a/network-orchestrator/group_vars/example.all.yml
+++ b/network-orchestrator/group_vars/example.all.yml
@@ -18,3 +18,14 @@ ntpservers:
 
 ntp_listen_interface: "eth0"
 default_timezone: "Europe/Zurich"
+
+# Non-standard or custom interface settings #
+#############################################
+# The configuration below is only applied   #
+# to interfaces that are of type "Other"    #
+#############################################
+other_interfaces:
+  leaf-DC1-01:
+    swp11:
+      - link-duplex half
+      - link-speed  100

--- a/network-orchestrator/roles/cumulus/templates/interfaces.j2
+++ b/network-orchestrator/roles/cumulus/templates/interfaces.j2
@@ -57,6 +57,11 @@ iface {{ iface.name }}
 {% if iface.tagged_vlans %}
     bridge-vids {{ iface.tagged_vlans | ranges }}
 {% endif %}
+{% if iface.form_factor == 'Other' and other_interfaces[ansible_hostname][iface.name] is defined %}
+{% for interface_setting in other_interfaces[ansible_hostname][iface.name] %}
+    {{ interface_setting }}
+{% endfor %}
+{% endif %}
 {% if iface.form_factor == '100BASE-TX (10/100ME)' %}
     link-autoneg on
     link-speed 100


### PR DESCRIPTION
This commit enables the user to configure custom settings for
specific interfaces by writing something like this in `network-orchestrator/group_vars/all.yml`:

    other_interfaces:
      leaf-DC1-01:
        swp11:
          - link-duplex half
          - link-speed  100

However, placing the config under `group_vars` isn't really natural. Maybe we should re-introduce the `custom_host_vars` directory and place the configuration there? Like this:

    $ cat network-orchestrator/custom_host_vars/leaf-DC1-01.yml
    other_interfaces:
        swp11:
          - link-duplex half
          - link-speed  100

I think that would fit more naturally. I am open to discuss this.

Either way - I suggest to please pull and merge this change first and discuss and fix the design after, following a "lazy" type of process.